### PR TITLE
The Ci now always gets a syslog in a separate step, so we can disable…

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -43,7 +43,6 @@ while true ; do
     fi
     if [[ ${COUNTER} -gt ${MAXCOUNT} ]]; then
         echo -e "\n\n\n\n$(date)\tERROR CONNECTION TIMEOUT...\n\n\n\n"
-        vagrant ssh -- sudo journalctl
         exit 23
     fi
     echo -n '.'


### PR DESCRIPTION
… this old workaround.
