### PR TITLE
install Vagrant from a download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM experimentalplatform/ubuntu:latest
 
 RUN apt-get -y update && apt-get -y install openssh-client && rm -rf /var/lib/apt/lists/*
 
-ADD vagrant_1.7.2_x86_64.deb /tmp/vagrant.deb
-RUN dpkg -i /tmp/vagrant.deb && \
-    rm -rf /tmp/vagrant.deb
+RUN FILE=$(mktemp); curl -L https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4_x86_64.deb > $FILE && dpkg -i $FILE; rm $FILE
 
 RUN vagrant plugin install vagrant-digitalocean
 RUN vagrant box add digital_ocean https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box


### PR DESCRIPTION
cuts down image size by ~70MB
